### PR TITLE
Add mixin-skills resource docs

### DIFF
--- a/developers-docs/docs/resources/ai-agent/_category_.json
+++ b/developers-docs/docs/resources/ai-agent/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Skills",
+  "position": 2,
+  "link": {
+    "type": "generated-index",
+    "description": "Use mixin-skills with an AI coding assistant to build Mixin bots, messaging flows, Safe operations, OAuth, and Computer integrations."
+  }
+}

--- a/developers-docs/docs/resources/ai-agent/authentication.md
+++ b/developers-docs/docs/resources/ai-agent/authentication.md
@@ -1,0 +1,35 @@
+---
+title: Authentication
+sidebar_position: 2
+---
+
+# Authentication
+
+Every bot that calls the Mixin API needs a keystore. It is a JSON file that stores the app identity and the credentials required to sign API requests.
+
+## Step 1 — Create an app
+
+1. Open [developers.mixin.one](https://developers.mixin.one) and sign in with Mixin Messenger.
+2. Click **New App**, fill in a name, and save.
+3. Go to **Secret** → **Session Secret**, then click **Generate new session**.
+4. Download the generated keystore JSON file immediately.
+
+## Step 2 — Add the spend key
+
+The downloaded keystore usually does not include `spend_private_key`. If the bot needs to perform Safe transfers, withdrawals, or other asset operations, generate and copy the spend key from **Secret** → **App Wallet**, then add it to the keystore manually:
+
+```json
+{
+  "app_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "session_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "server_public_key": "hex...",
+  "session_private_key": "hex...",
+  "spend_private_key": "hex..."
+}
+```
+
+:::warning
+`spend_private_key` is shown only once. It can move assets from the bot, so store it carefully and never commit it to a repository or write it to logs.
+:::
+
+Save this file as `keystore.json`. You can now run examples or ask an AI assistant to generate Mixin code from it.

--- a/developers-docs/docs/resources/ai-agent/capabilities.md
+++ b/developers-docs/docs/resources/ai-agent/capabilities.md
@@ -1,0 +1,50 @@
+---
+title: Capabilities
+sidebar_position: 4
+---
+
+# Capabilities
+
+[mixin-skills](https://github.com/LixvYang/mixin-skills) loads Mixin guidance according to the development task, helping AI assistants generate code that is closer to official SDK usage.
+
+## Skills Coverage
+
+| Skill | Covers |
+|-------|--------|
+| `mixin-bot` | Keystore loading, JWT auth, messaging, Blaze WebSocket, conversation management |
+| `mixin-safe` | Safe UTXO transfers, withdrawals, ghost keys, MixAddress, asset and snapshot queries |
+| `mixin-computer` | Mixin Computer client, AddUser, SystemCall |
+| `mixin-mtg-multisig` | MTG programs, observer / signer, FROST signing sessions |
+| `mixin-oauth` | Mixin OAuth login, including frontend PKCE and backend `client_secret` flows |
+
+## Messaging
+
+| Action | Related SDK / API |
+|--------|-------------------|
+| Send text message | `client.message.sendText(userId, text)` |
+| Send an App Card | `client.message.sendLegacy({ category: "APP_CARD", ... })` |
+| Receive realtime messages | Blaze WebSocket loop |
+| Create / manage group | `client.conversation.create()` |
+
+## Wallet and Assets
+
+| Action | Related SDK / API |
+|--------|-------------------|
+| Query Safe balances | Aggregate UTXOs returned by `client.utxo.safeOutputs()` |
+| Fetch asset metadata | `client.safe.fetchAssets([assetId])` |
+| Query balance changes | `/safe/snapshots` or the SDK Safe snapshots method |
+
+## Transfers
+
+All Safe transfers, withdrawals, and multisig asset operations require `spend_private_key`.
+
+| Action | Example |
+|--------|---------|
+| Transfer to a user | [05-transfer](https://github.com/LixvYang/mixin-ai-agent-demo/blob/main/examples/05-transfer.mjs) |
+| Transfer all assets | `safe-transfer-all.mjs` in the `mixin-safe` skill |
+
+## OAuth
+
+Use the `mixin-oauth` skill when you want users to sign in to a web app with Mixin. Backend authorization-code exchange requires `client_secret` from the developer dashboard. The frontend PKCE flow does not put `client_secret` in the browser.
+
+See the [OAuth API documentation](/docs/api/oauth) for more details.

--- a/developers-docs/docs/resources/ai-agent/introduction.md
+++ b/developers-docs/docs/resources/ai-agent/introduction.md
@@ -1,0 +1,16 @@
+---
+title: Introduction
+sidebar_position: 1
+---
+
+# Skills
+
+[mixin-skills](https://github.com/LixvYang/mixin-skills) is a context package for AI coding assistants. After installation, your AI agent can recognize Mixin Network development tasks and provide code guidance for Mixin bots, Safe transfers, OAuth, and related SDK usage.
+
+## Install
+
+```bash
+npx skills add LixvYang/mixin-skills
+```
+
+Once installed, the AI assistant can load the matching skill when you ask it to build a Mixin bot, handle a Safe transfer, configure OAuth, or work with Mixin Computer. The skill gives the assistant focused examples and SDK notes for the task.

--- a/developers-docs/docs/resources/ai-agent/quick-start.md
+++ b/developers-docs/docs/resources/ai-agent/quick-start.md
@@ -1,0 +1,81 @@
+---
+title: Quick Start
+sidebar_position: 2
+---
+
+# Quick Start
+
+This page does not ask you to memorize every Mixin SDK call. Instead, it shows how to let an AI coding assistant read `mixin-skills` and a runnable demo repository in a clean directory, then complete the first real action for you.
+
+## Step 1: Prepare a workspace
+
+Create a new directory and place your bot `keystore.json` inside it:
+
+```bash
+mkdir mixin-agent-playground
+cd mixin-agent-playground
+cp /path/to/keystore.json ./keystore.json
+chmod 600 keystore.json
+```
+
+:::warning
+Do not commit `keystore.json` to a repository, and do not let the AI assistant print the full keystore in its response. The `spend_private_key` can move assets from the bot.
+:::
+
+## Step 2: Give the task to AI
+
+Open your AI coding assistant in this directory and send it this prompt:
+
+```text
+You are now in a clean Mixin development directory. The current directory contains keystore.json.
+
+Download and read these two repositories in the current directory:
+
+1. https://github.com/LixvYang/mixin-skills
+2. https://github.com/LixvYang/mixin-ai-agent-demo
+
+Requirements:
+
+- First read mixin-skills/README.md and understand which skill applies to each task.
+- Then read mixin-ai-agent-demo/README.md and the examples directory.
+- Do not print the full keystore.json content, and do not commit the keystore to git.
+- List which demo examples can run directly, such as 01-ping, 02-balance, and 03-send-message.
+- Run the smallest validation command first to confirm the keystore works.
+- Then complete one real action: send a Mixin message to this bot's creator.
+- If the existing demo cannot directly discover the creator user_id, check whether client.user.profile() returns app.creator_id. If it does, use that value. If it does not, tell me which user_id I need to provide.
+```
+
+The assistant will usually start with commands like these:
+
+```bash
+git clone https://github.com/LixvYang/mixin-skills.git
+git clone https://github.com/LixvYang/mixin-ai-agent-demo.git
+cd mixin-ai-agent-demo
+npm install
+node examples/01-ping.mjs --config=../keystore.json
+```
+
+`01-ping` reads the keystore and requests the bot's own Mixin profile. If it succeeds, `app_id`, `session_id`, and `session_private_key` can sign API requests correctly.
+
+## Step 3: Run the first action
+
+Ask the assistant to find the message-sending example. In the current demo, it is usually:
+
+```bash
+node examples/03-send-message.mjs \
+  --config=../keystore.json \
+  --to=CREATOR_USER_ID \
+  --text="Hello from my Mixin bot"
+```
+
+If the assistant can read `app.creator_id` from `client.user.profile()`, it can use that creator `user_id` as `--to`. If it cannot discover the creator automatically, provide your own Mixin `user_id` and let the assistant replace `CREATOR_USER_ID`.
+
+## What you should see
+
+After the command runs, you should receive a message from the bot in Mixin Messenger. This confirms three things:
+
+1. The keystore works for API authentication.
+2. The AI assistant can use `mixin-skills` to find the right Mixin development context.
+3. The demo code can run locally and complete a real Mixin message send.
+
+Next, ask the assistant to inspect `02-balance`, `04-echo-bot`, or `05-transfer` to validate Safe balance queries, the Blaze realtime message loop, and Safe transfers.

--- a/developers-docs/docs/resources/ai-agent/quick-start.md
+++ b/developers-docs/docs/resources/ai-agent/quick-start.md
@@ -1,6 +1,6 @@
 ---
 title: Quick Start
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # Quick Start

--- a/developers-docs/i18n/en/docusaurus-plugin-content-docs/current.json
+++ b/developers-docs/i18n/en/docusaurus-plugin-content-docs/current.json
@@ -86,5 +86,9 @@
   "sidebar.api.category.Circles": {
     "message": "Circles",
     "description": "The label for category Circles in sidebar api"
+  },
+  "sidebar.docs.category.Skills": {
+    "message": "Skills",
+    "description": "The label for category 'Skills' in sidebar 'docs'"
   }
 }

--- a/developers-docs/i18n/zh-CN/docusaurus-plugin-content-docs/current.json
+++ b/developers-docs/i18n/zh-CN/docusaurus-plugin-content-docs/current.json
@@ -103,6 +103,10 @@
     "message": "资源",
     "description": "The label for category Resources in sidebar docs"
   },
+  "sidebar.docs.category.Skills": {
+    "message": "Skill",
+    "description": "The label for category 'Skills' in sidebar 'docs'"
+  },
   "sidebar.docs.category.Community": {
     "message": "社区",
     "description": "The label for category Community in sidebar docs"

--- a/developers-docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/resources/ai-agent/authentication.md
+++ b/developers-docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/resources/ai-agent/authentication.md
@@ -1,0 +1,35 @@
+---
+title: 认证
+sidebar_position: 2
+---
+
+# 认证
+
+所有需要访问 Mixin API 的 Bot 都要使用 keystore。它是一个 JSON 文件，保存应用身份和签名请求所需的凭证。
+
+## 第一步：创建应用
+
+1. 打开 [developers.mixin.one](https://developers.mixin.one)，使用 Mixin Messenger 登录。
+2. 点击 **New App**，填写应用名称并保存。
+3. 进入 **密钥** → **会话密钥**，点击 **生成新的密钥**。
+4. 立即下载生成的 keystore JSON 文件。
+
+## 第二步：添加 spend key
+
+下载的 keystore 通常不包含 `spend_private_key`。如果 Bot 需要执行 Safe 转账、提现等资产操作，需要在 **Secret** → **App Wallet** 中生成并复制 spend key，然后手动加入 keystore：
+
+```json
+{
+  "app_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "session_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "server_public_key": "hex...",
+  "session_private_key": "hex...",
+  "spend_private_key": "hex..."
+}
+```
+
+:::warning
+`spend_private_key` 只会显示一次。它拥有转移 Bot 资产的权限，请妥善保存，不要提交到代码仓库或写入日志。
+:::
+
+将这个文件保存为 `keystore.json` 后，就可以运行示例或让 AI 助手基于它生成 Mixin 代码。

--- a/developers-docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/resources/ai-agent/capabilities.md
+++ b/developers-docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/resources/ai-agent/capabilities.md
@@ -1,0 +1,50 @@
+---
+title: 能力
+sidebar_position: 4
+---
+
+# 能力
+
+[mixin-skills](https://github.com/LixvYang/mixin-skills) 会根据开发场景加载对应的 Mixin 指南，帮助 AI 助手生成更接近官方 SDK 用法的代码。
+
+## 技能覆盖范围
+
+| 技能 | 覆盖内容 |
+|------|----------|
+| `mixin-bot` | keystore 加载、JWT 认证、消息收发、Blaze WebSocket、会话管理 |
+| `mixin-safe` | Safe UTXO 转账、提现、ghost key、MixAddress、资产和快照查询 |
+| `mixin-computer` | Mixin Computer 客户端、AddUser、SystemCall |
+| `mixin-mtg-multisig` | MTG 程序、observer / signer、FROST 签名会话 |
+| `mixin-oauth` | Mixin OAuth 登录，包含前端 PKCE 和后端 `client_secret` 流程 |
+
+## 消息
+
+| 操作 | 相关 SDK / 接口 |
+|------|-----------------|
+| 发送文本消息 | `client.message.sendText(userId, text)` |
+| 发送 App Card | `client.message.sendLegacy({ category: "APP_CARD", ... })` |
+| 接收实时消息 | Blaze WebSocket loop |
+| 创建或管理群组 | `client.conversation.create()` |
+
+## 钱包和资产
+
+| 操作 | 相关 SDK / 接口 |
+|------|-----------------|
+| 查询 Safe 余额 | 聚合 `client.utxo.safeOutputs()` 返回的 UTXO |
+| 获取资产信息 | `client.safe.fetchAssets([assetId])` |
+| 查询余额变动 | `/safe/snapshots` 或 SDK 的 Safe snapshots 方法 |
+
+## 转账
+
+所有 Safe 转账、提现、multisig 资产操作都需要 `spend_private_key`。
+
+| 操作 | 示例 |
+|------|------|
+| 转账给用户 | [05-transfer](https://github.com/LixvYang/mixin-ai-agent-demo/blob/main/examples/05-transfer.mjs) |
+| 转出全部资产 | `mixin-safe` skill 中的 `safe-transfer-all.mjs` |
+
+## OAuth
+
+如果要让用户通过 Mixin 登录网页应用，可以使用 `mixin-oauth` skill。后端授权码交换需要在开发者后台获取 `client_secret`，前端 PKCE 流程则不需要把 `client_secret` 放到浏览器。
+
+更多细节见 [OAuth API 文档](/docs/api/oauth)。

--- a/developers-docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/resources/ai-agent/introduction.md
+++ b/developers-docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/resources/ai-agent/introduction.md
@@ -1,0 +1,16 @@
+---
+title: 简介
+sidebar_position: 1
+---
+
+# Skills
+
+mixin-skills 是 AI 编程助手的上下文技能包，安装后 AI Agent 可以自动识别你的开发场景，提供 Mixin Network 相关的代码编写指导。
+
+## 安装
+
+```bash
+npx skills add LixvYang/mixin-skills
+```
+
+安装后，当你在 AI Agent 中编写 Mixin Bot、处理 Safe 转账、配置 OAuth 等操作时，它会自动加载对应 Skill，直接给出代码示例和 SDK 使用说明。

--- a/developers-docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/resources/ai-agent/quick-start.md
+++ b/developers-docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/resources/ai-agent/quick-start.md
@@ -1,0 +1,81 @@
+---
+title: 快速开始
+sidebar_position: 2
+---
+
+# 快速开始
+
+这一页不是让你手动记住所有 Mixin SDK 调用，而是让 AI 助手在一个干净目录里读取 `mixin-skills` 和可运行 demo，然后帮你完成第一个真实动作。
+
+## 第一步：准备工作目录
+
+新建一个目录，并把 Bot 的 `keystore.json` 放进去：
+
+```bash
+mkdir mixin-agent-playground
+cd mixin-agent-playground
+cp /path/to/keystore.json ./keystore.json
+chmod 600 keystore.json
+```
+
+:::warning
+不要把 `keystore.json` 提交到代码仓库，也不要让 AI 在回复里打印完整 keystore。尤其是 `spend_private_key`，它拥有转移 Bot 资产的权限。
+:::
+
+## 第二步：把任务交给 AI
+
+在这个目录里打开你的 AI 编程助手，把下面这段话发给它：
+
+```text
+你现在位于一个干净的 Mixin 开发目录，当前目录里有 keystore.json。
+
+请在当前目录下载并阅读这两个代码库：
+
+1. https://github.com/LixvYang/mixin-skills
+2. https://github.com/LixvYang/mixin-ai-agent-demo
+
+要求：
+
+- 先阅读 mixin-skills/README.md，理解每个 skill 适合什么场景。
+- 再阅读 mixin-ai-agent-demo/README.md 和 examples 目录。
+- 不要打印 keystore.json 的完整内容，不要把 keystore 提交到 git。
+- 列出 demo 里有哪些可以直接运行的示例，例如 01-ping、02-balance、03-send-message。
+- 先运行最小验证命令，确认 keystore 可用。
+- 然后帮我完成一个真实动作：给这个 Bot 的创建者发送一条 Mixin 消息。
+- 如果现有 demo 不能直接获取创建者 user_id，请先检查 client.user.profile() 的返回值里是否有 app.creator_id；如果有，就使用它。如果没有，请告诉我需要提供哪个 user_id。
+```
+
+AI 通常会先执行类似下面的命令：
+
+```bash
+git clone https://github.com/LixvYang/mixin-skills.git
+git clone https://github.com/LixvYang/mixin-ai-agent-demo.git
+cd mixin-ai-agent-demo
+npm install
+node examples/01-ping.mjs --config=../keystore.json
+```
+
+`01-ping` 会读取 keystore，并请求 Bot 自己的 Mixin profile。这个步骤通过后，说明 `app_id`、`session_id`、`session_private_key` 可以正常签名请求。
+
+## 第三步：运行第一个动作
+
+让 AI 找到发送消息的示例。当前 demo 中通常是：
+
+```bash
+node examples/03-send-message.mjs \
+  --config=../keystore.json \
+  --to=CREATOR_USER_ID \
+  --text="Hello from my Mixin bot"
+```
+
+如果 AI 能从 `client.user.profile()` 里读取到 `app.creator_id`，它可以直接用创建者的 `user_id` 作为 `--to`。如果不能自动获取，就把你的 Mixin `user_id` 提供给 AI，让它代入 `CREATOR_USER_ID`。
+
+## 你应该看到什么
+
+完成后，你应该在 Mixin Messenger 里收到 Bot 发来的消息。这个说明三件事已经跑通：
+
+1. keystore 可以用于 API 认证。
+2. AI 已经能根据 `mixin-skills` 找到正确的开发上下文。
+3. demo 代码可以在你的本地目录里运行，并完成真实的 Mixin 消息发送。
+
+下一步可以继续让 AI 查看 `02-balance`、`04-echo-bot` 或 `05-transfer`，分别验证 Safe 余额查询、Blaze 实时消息循环和 Safe 转账。

--- a/developers-docs/sidebar.docs.js
+++ b/developers-docs/sidebar.docs.js
@@ -176,6 +176,17 @@ module.exports = {
       collapsed: false,
       items: [
         'resources/sdk',
+        {
+          label: 'Skills',
+          type: 'category',
+          collapsed: false,
+          items: [
+            'resources/ai-agent/introduction',
+            'resources/ai-agent/authentication',
+            'resources/ai-agent/quick-start',
+            'resources/ai-agent/capabilities',
+          ]
+        },
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Add Resources > Skills docs for mixin-skills in English
- Add zh-CN translations for the Skills docs
- Add sidebar and i18n entries for the new Skills section

## Verification
- npm run build

Note: Docusaurus reported existing broken-link warnings in unrelated pages, but the build completed successfully.