### PR TITLE
build(deps): remediate patchable high severity alerts

### DIFF
--- a/developers-docs/pnpm-lock.yaml
+++ b/developers-docs/pnpm-lock.yaml
@@ -5,7 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  fast-uri@>=3.0.0 <=3.1.3: 3.1.4
+  fast-uri@>=3.0.0 <=3.1.4: 3.1.5
+  nanoid: 3.3.17
   serialize-javascript@<=7.0.2: '>=7.0.3'
   svgo@>=3.0.0 <3.3.4: 3.3.4
   uuid@<11.1.1: 11.1.1
@@ -2757,8 +2758,8 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -3696,8 +3697,8 @@ packages:
     resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
     hasBin: true
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -8199,7 +8200,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -9131,7 +9132,7 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.20.1:
     dependencies:
@@ -10362,7 +10363,7 @@ snapshots:
       dns-packet: 5.6.1
       thunky: 1.1.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   negotiator@0.6.3: {}
 
@@ -11006,7 +11007,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/developers-docs/pnpm-lock.yaml
+++ b/developers-docs/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   fast-uri@>=3.0.0 <=3.1.4: 3.1.5
-  nanoid: 3.3.17
+  nanoid: 3.3.18
   serialize-javascript@<=7.0.2: '>=7.0.3'
   svgo@>=3.0.0 <3.3.4: 3.3.4
   uuid@<11.1.1: 11.1.1
@@ -3697,8 +3697,8 @@ packages:
     resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
     hasBin: true
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -10363,7 +10363,7 @@ snapshots:
       dns-packet: 5.6.1
       thunky: 1.1.0
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   negotiator@0.6.3: {}
 
@@ -11007,7 +11007,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/developers-docs/pnpm-workspace.yaml
+++ b/developers-docs/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ allowBuilds:
   core-js: false
 overrides:
   'fast-uri@>=3.0.0 <=3.1.4': 3.1.5
-  nanoid: 3.3.17
+  nanoid: 3.3.18
   serialize-javascript@<=7.0.2: '>=7.0.3'
   'svgo@>=3.0.0 <3.3.4': 3.3.4
   uuid@<11.1.1: 11.1.1

--- a/developers-docs/pnpm-workspace.yaml
+++ b/developers-docs/pnpm-workspace.yaml
@@ -2,7 +2,8 @@ allowBuilds:
   '@parcel/watcher': false
   core-js: false
 overrides:
-  'fast-uri@>=3.0.0 <=3.1.3': 3.1.4
+  'fast-uri@>=3.0.0 <=3.1.4': 3.1.5
+  nanoid: 3.3.17
   serialize-javascript@<=7.0.2: '>=7.0.3'
   'svgo@>=3.0.0 <3.3.4': 3.3.4
   uuid@<11.1.1: 11.1.1

--- a/developers/pnpm-lock.yaml
+++ b/developers/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  nanoid: 3.3.17
+
 importers:
 
   .:
@@ -1714,8 +1717,8 @@ packages:
     resolution: {integrity: sha512-s06EY41x1hM6BJE2HhIFRzvXuVUlZNd4761lduv+hjgtDDR7W4RzhShkap2wJcWMO6+CahR+49cCQJfFmgf7gw==}
     engines: {node: '>=4.0.0'}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -4128,7 +4131,7 @@ snapshots:
 
   nano-seconds@1.2.2: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   natural-compare@1.4.0: {}
 
@@ -4317,13 +4320,13 @@ snapshots:
 
   postcss@8.5.20:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/developers/pnpm-lock.yaml
+++ b/developers/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  nanoid: 3.3.17
+  nanoid: 3.3.18
 
 importers:
 
@@ -1717,8 +1717,8 @@ packages:
     resolution: {integrity: sha512-s06EY41x1hM6BJE2HhIFRzvXuVUlZNd4761lduv+hjgtDDR7W4RzhShkap2wJcWMO6+CahR+49cCQJfFmgf7gw==}
     engines: {node: '>=4.0.0'}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -4131,7 +4131,7 @@ snapshots:
 
   nano-seconds@1.2.2: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -4320,13 +4320,13 @@ snapshots:
 
   postcss@8.5.20:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/developers/pnpm-workspace.yaml
+++ b/developers/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 allowBuilds:
   '@parcel/watcher': false
 overrides:
-  nanoid: 3.3.17
+  nanoid: 3.3.18

--- a/developers/pnpm-workspace.yaml
+++ b/developers/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 allowBuilds:
   '@parcel/watcher': false
+overrides:
+  nanoid: 3.3.17


### PR DESCRIPTION
Pins patched nanoid and fast-uri versions across the developer frontend and documentation site.

Validation:
- corepack pnpm@11.18.0 install --frozen-lockfile (both projects)
- developers: audit has 0 High / 0 Critical; production build passes
- developers-docs: production build passes; nanoid and fast-uri resolve to patched versions
- git diff --check

The documentation site still resolves image-size 2.0.2 through the latest @docusaurus/mdx-loader 3.10.2. GitHub marks both associated alerts as having no patched release, and image-size 2.0.3 is not published in npm, so this PR intentionally does not claim to close those two alerts.